### PR TITLE
Fixes for package.html

### DIFF
--- a/src/java/com/opensymphony/sitemesh/compatability/package.html
+++ b/src/java/com/opensymphony/sitemesh/compatability/package.html
@@ -1,1 +1,3 @@
-Compatability classes to enable easy migration of SiteMesh 1 and 2 applications to SiteMesh 3.
+<body>
+<p>Compatibility classes to enable easy migration of SiteMesh 1 and 2 applications to SiteMesh 3.</p>
+</body>

--- a/src/java/com/opensymphony/sitemesh/webapp/package.html
+++ b/src/java/com/opensymphony/sitemesh/webapp/package.html
@@ -1,1 +1,3 @@
+<body>
 <p>Provides integration of SiteMesh with Java web-applications.</p>
+</body>


### PR DESCRIPTION
The package.html files need to be valid HTML (that is, including a <body> tag) for javadoc to parse and include them without error.
