### PR TITLE
ContentBufferingResponse needs to call setContentType on wrapper in constructor

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -18,4 +18,4 @@ compile.nowarn = off
 
 Name = OpenSymphony SiteMesh
 name = sitemesh
-version = 2.5-atlassian-5
+version = 2.5-atlassian-6

--- a/pom.xml
+++ b/pom.xml
@@ -6,18 +6,26 @@
     <!--
     ant clean test
     ant clean jar sources
-    mvn deploy:deploy-file -Dfile=./dist/sitemesh-2.5-atlassian-5.jar -DpomFile=./pom.xml -Durl=https://maven.atlassian.com/public -DrepositoryId=atlassian-public
-    mvn deploy:deploy-file -Dfile=./dist/sitemesh-2.5-atlassian-5-sources.jar -DpomFile=./pom.xml -Dclassifier=sources -Durl=https://maven.atlassian.com/public -DrepositoryId=atlassian-public
+    (for local testing) mvn install:install-file -Dfile=./dist/sitemesh-2.5-atlassian-6.jar -DpomFile=./pom.xml
+    mvn deploy:deploy-file -Dfile=./dist/sitemesh-2.5-atlassian-6.jar -DpomFile=./pom.xml -Durl=https://maven.atlassian.com/public -DrepositoryId=atlassian-public
+    mvn deploy:deploy-file -Dfile=./dist/sitemesh-2.5-atlassian-6-sources.jar -DpomFile=./pom.xml -Dclassifier=sources -Durl=https://maven.atlassian.com/public -DrepositoryId=atlassian-public
     -->
 
     <groupId>opensymphony</groupId>
     <artifactId>sitemesh</artifactId>
-    <version>2.5-atlassian-5</version>
+    <version>2.5-atlassian-6</version>
     
     <packaging>jar</packaging>
     <name>SiteMesh</name>
     <description>Atlassian's fork of SiteMesh</description>
     <url>https://github.com/atlassian/sitemesh2</url>
 
-
+    <dependencies>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.4</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/java/com/opensymphony/sitemesh/webapp/ContentBufferingResponse.java
+++ b/src/java/com/opensymphony/sitemesh/webapp/ContentBufferingResponse.java
@@ -43,6 +43,14 @@ public class ContentBufferingResponse extends HttpServletResponseWrapper {
         this.contentProcessor = contentProcessor;
         this.webAppContext = webAppContext;
         pageResponseWrapper = (PageResponseWrapper) getResponse();
+
+        // We can't guarantee that response.setContentType will not be
+        // called before this constructor, so we must check the type now.
+        String existingContentType = response.getContentType();
+        if (existingContentType != null)
+        {
+            pageResponseWrapper.setContentType(existingContentType);
+        }
     }
 
     public boolean isUsingStream() {


### PR DESCRIPTION
This changest fixes a bug where the PageResponseWrapper's setContentType method is never called and SiteMesh fails to activate.

Bumps the version to 2.5-atlassian-6
