### PR TITLE
Restore API compatibility

### DIFF
--- a/src/java/com/opensymphony/module/sitemesh/filter/PageResponseWrapper.java
+++ b/src/java/com/opensymphony/module/sitemesh/filter/PageResponseWrapper.java
@@ -40,8 +40,16 @@ public class PageResponseWrapper extends HttpServletResponseWrapper {
     private final ScalabilitySupport scalabilitySupport;
     private final HttpServletRequest request;
 
+    public PageResponseWrapper(final HttpServletResponse response, final PageParserSelector parserSelector) {
+        this(response, null, new NoopScalabilitySupport(), parserSelector);
+    }
+
     public PageResponseWrapper(final HttpServletResponse response, final HttpServletRequest request, final PageParserSelector parserSelector) {
         this(response, request, new NoopScalabilitySupport(), parserSelector);
+    }
+
+    public PageResponseWrapper(final HttpServletResponse response, final ScalabilitySupport scalabilitySupport, final PageParserSelector parserSelector) {
+        this(response, null, scalabilitySupport, parserSelector);
     }
 
     public PageResponseWrapper(final HttpServletResponse response, final HttpServletRequest request, final ScalabilitySupport scalabilitySupport, final PageParserSelector parserSelector) {
@@ -101,7 +109,7 @@ public class PageResponseWrapper extends HttpServletResponseWrapper {
     }
 
     private boolean lazyDisable() {
-        if (request.getAttribute(RequestConstants.DISABLE_BUFFER_AND_DECORATION) != null) {
+        if (null != request && request.getAttribute(RequestConstants.DISABLE_BUFFER_AND_DECORATION) != null) {
             parseablePage = false;
             buffer = null;
             return true;

--- a/src/java/com/opensymphony/sitemesh/webapp/ContentBufferingResponse.java
+++ b/src/java/com/opensymphony/sitemesh/webapp/ContentBufferingResponse.java
@@ -26,6 +26,10 @@ public class ContentBufferingResponse extends HttpServletResponseWrapper {
     private final ContentProcessor contentProcessor;
     private final SiteMeshWebAppContext webAppContext;
 
+    public ContentBufferingResponse(HttpServletResponse response, final ContentProcessor contentProcessor, final SiteMeshWebAppContext webAppContext, final ScalabilitySupport scalabilitySupport) {
+        this(response, null, contentProcessor, webAppContext, scalabilitySupport);
+    }
+
     public ContentBufferingResponse(HttpServletResponse response, HttpServletRequest request, final ContentProcessor contentProcessor, final SiteMeshWebAppContext webAppContext, final ScalabilitySupport scalabilitySupport) {
         super(new PageResponseWrapper(response, request,  scalabilitySupport, new PageParserSelector() {
             public boolean shouldParsePage(String contentType) {


### PR DESCRIPTION
Spud's fix changes public constructors for PageResponseWrapper, ContentBufferingResponse by adding an HttpServletRequest param. Reinstate old constructors to backwards compatibility.

In the case where the old constructor is used, a null request is passed; this means that  request attributes will not be inspected to see if sitemesh has been disabled.
